### PR TITLE
Updated for google-cloud-monitoring and --align-period-seconds param

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,7 +137,8 @@ $ gcpmetrics --keyfile ./keyfile.json \
     --query --days 2 \
     --metric appengine.googleapis.com/system/cpu/usage \
     --reduce REDUCE_SUM \
-    --align ALIGN_SUM
+    --align ALIGN_SUM \
+    --align-period-seconds 300
 
 ALIGN: ALIGN_SUM seconds: 172800.0
 REDUCE: REDUCE_SUM grouping: None
@@ -366,32 +367,34 @@ usage: gcpmetrics [-h] [--version] [--init-config DIR] [--config FILE]
                   [--list-resources] [--list-metrics] [--query] [--service ID]
                   [--metric ID] [--infinite] [--days INT] [--hours INT]
                   [--minutes INT] [--resource-filter S] [--metric-filter S]
-                  [--align A] [--reduce R] [--reduce-grouping R] [--iloc00]
+                  [--align A] [--align-period-seconds A] [--reduce R]
+                  [--reduce-grouping R] [--iloc00]
 
 Google Cloud Monitoring API Command Line
 Website: https://github.com/odin-public/gcpmetrics
 
 optional arguments:
-  -h, --help           show this help message and exit
-  --version            Print gcpmetics version and exit.
-  --init-config DIR    Location of configuration files.
-  --config FILE        Local configuration *.yaml file to be used.
-  --keyfile FILE       Goolge Cloud Platform service account key file.
-  --preset ID          Preset ID, like http_response_5xx_sum, etc.
-  --project ID         Project ID.
-  --list-resources     List monitored resource descriptors and exit.
-  --list-metrics       List available metric descriptors and exit.
-  --query              Run the time series query.
-  --service ID         Service ID.
-  --metric ID          Metric ID as defined by Google Monitoring API.
-  --infinite           Calculate time delta since the dawn of time.
-  --days INT           Days from now to calculate the query start date.
-  --hours INT          Hours from now to calculate the query start date.
-  --minutes INT        Minutes from now to calculate the query start date.
-  --resource-filter S  Filter of resources in the var:val[,var:val] format.
-  --metric-filter S    Filter of metrics in the var:val[,var:val] format.
-  --align A            Alignment of data ALIGN_NONE, ALIGN_SUM. etc.
-  --reduce R           Reduce of data REDUCE_NONE, REDUCE_SUM, etc.
-  --reduce-grouping R  Reduce grouping in the var1[,var2] format.
-  --iloc00             Print value from the table index [0:0] only.
+  -h, --help                show this help message and exit
+  --version                 Print gcpmetics version and exit.
+  --init-config DIR         Location of configuration files.
+  --config FILE             Local configuration *.yaml file to be used.
+  --keyfile FILE            Goolge Cloud Platform service account key file.
+  --preset ID               Preset ID, like http_response_5xx_sum, etc.
+  --project ID              Project ID.
+  --list-resources          List monitored resource descriptors and exit.
+  --list-metrics            List available metric descriptors and exit.
+  --query                   Run the time series query.
+  --service ID              Service ID.
+  --metric ID               Metric ID as defined by Google Monitoring API.
+  --infinite                Calculate time delta since the dawn of time.
+  --days INT                Days from now to calculate the query start date.
+  --hours INT               Hours from now to calculate the query start date.
+  --minutes INT             Minutes from now to calculate the query start date.
+  --resource-filter S       Filter of resources in the var:val[,var:val] format.
+  --metric-filter S         Filter of metrics in the var:val[,var:val] format.
+  --align A                 Alignment of data ALIGN_NONE, ALIGN_SUM. etc.
+  --align-period-seconds A  Alignment period in seconds.  Default: 300 seconds.
+  --reduce R                Reduce of data REDUCE_NONE, REDUCE_SUM, etc.
+  --reduce-grouping R       Reduce grouping in the var1[,var2] format.
+  --iloc00                  Print value from the table index [0:0] only.
 ```

--- a/gcpmetrics/keyfile-template.json
+++ b/gcpmetrics/keyfile-template.json
@@ -4,63 +4,9 @@
 
 {
   "type": "service_account",
-  "project_id": "...",
-   ...
-}
-~                                                                                                                                                                                                                 
-~                                                                                                                                                                                                                 
-~                                                                                                                                                                                                                 
-~                                                                                                                                                                                                                 
-~                                                                                                                                                                                                                 
-~                                                                                                                                                                                                                 
-~                                                                                                                                                                                                                 
-~                                                                                                                                                                                                                 
-~                                                                                                                                                                                                                 
-~                                                                                                                                                                                                                 
-~                                                                                                                                                                                                                 
-~                                                                                                                                                                                                                 
-~                                                                                                                                                                                                                 
-~                                                                                                                                                                                                                 
-~                                                                                                                                                                                                                 
-~                                                                                                                                                                                                                 
-~                                                                                                                                                                                                                 
-~                                                                                                                                                                                                                 
-~                                                                                                                                                                                                                 
-~                                                                                                                                                                                                                 
-~                                                                                                                                                                                                                 
-~                                                                                                                                                                                                                 
-~                                                                                                                                                                                                                 
-~                                                                                                                                                                                                                 
-~                                                                                                                                                                                                                 
-~                                                                                                                                                                                                                 
-~                                                                                                                                                                                                                 
-~                                                                                                                                                                                                                 
-~                                                                                                                                                                                                                 
-~                                                                                                                                                                                                                 
-~                                                                                                                                                                                                                 
-~                                                                                                                                                                                                                 
-~                                                                                                                                                                                                                 
-~                                                                                                                                                                                                                 
-~                                                                                                                                                                                                                 
-~                                                                                                                                                                                                                 
-~                                                                                                                                                                                                                 
-~                                                                                                                                                                                                                 
-~                                                                                                                                                                                                                 
-~                                                                                                                                                                                                                 
-~                                                                                                                                                                                                                 
-~                                                                                                                                                                                                                 
-"./keyfile.json" 12L, 2344C
-
-
-
-
-
-
-
-ce_account",
   "project_id": "imc-hub-us-central-demo1",
   "private_key_id": "463e51219a069a0d338bb10a23eae5e01dd21b9e",
-  "private_key": "-----BEGIN PRIVATE KEY-----\nMIIEvwIBADANBgkqhkiG9w0BAQEFAASCBKkwggSlAgEAAoIBAQDKTtclwpmja/Q7\nxY8qnye5KCSPuy42EoOQfZvJfvZoIN9HZ8eKXoeYuDB5KZjJFVxt3th+P+H0Pyqj\nL+wpI7iIBr1tC7viRxuBbp+sgEdkwQW
+  "private_key": "-----BEGIN PRIVATE KEY-----\nMIIEvwIBADANBgkqhkiG9w0BAQEFAASCBKkwggSlAgEAAoIBAQDKTtclwpmja/Q7\nxY8qnye5KCSPuy42EoOQfZvJfvZoIN9HZ8eKXoeYuDB5KZjJFVxt3th+P+H0Pyqj\nL+wpI7iIBr1tC7viRxuBbp+sgEdkwQW",
   "client_email": "imc-hub-us-central-demo1@appspot.gserviceaccount.com",
   "client_id": "111368010698332321277",
   "auth_uri": "https://accounts.google.com/o/oauth2/auth",

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
-twine
-flake8
-gcloud
-pandas
-pyyaml
+twine==1.13.0
+flake8==3.7.7
+google-cloud-monitoring==0.31.1
+pandas==0.24.2
+PyYAML==5.1


### PR DESCRIPTION
Overview:
- Incorporates updates from PR #3 (*Fix display of data frame*)
- Pinned package versions in requirements.txt
- Updated to use new/recommended `google-cloud-monitoring` package (instead of gcloud)
- Removed `_build_label_filter()` function and calling code, since https://github.com/GoogleCloudPlatform/gcloud-python/pull/2234 was merged and included since release 0.19.0 https://github.com/googleapis/google-cloud-python/pull/2270
- Added `--align-period-seconds` parameter (default: 300 seconds)
- Fixed formatting in example keyfile-template.json
- Updated README.md with new parameter (example usage and added to help output)

Breaking changes:
- The default align period seconds is now 300 seconds instead of the total seconds specified by --day, --hours and --minutes parameters.